### PR TITLE
fix bug with the the explorer not scrollable

### DIFF
--- a/src/wrapper.css
+++ b/src/wrapper.css
@@ -1,6 +1,8 @@
 .graphiql-explorer-root {
   font-size: var(--body-font-size) !important;
   font-family: var(--editor-font-family) !important;
+  overflow: auto !important;
+  height: calc(100vh - 60px);
 }
 .graphiql-explorer-root svg path {
   fill: var(--theme-font-color) !important;


### PR DESCRIPTION
fix bug with the the explorer not scrollable if there are more queries than one screen size can fit 

Bug:
https://ibb.co/fFQHsxM
![Screenshot 2021-09-18 at 14 13 03](https://user-images.githubusercontent.com/13088968/133888551-a5fdb949-9fa0-4876-8f68-52993483081a.png)

Fix:
https://ibb.co/4P8C2
![Screenshot 2021-09-18 at 14 12 04](https://user-images.githubusercontent.com/13088968/133888544-eca40636-7ad5-456b-af17-2f849893f277.png)
wL